### PR TITLE
Adding EnableECDH to Context

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -46,16 +46,8 @@ static long SSL_CTX_add_extra_chain_cert_not_a_macro(SSL_CTX* ctx, X509 *cert) {
     return SSL_CTX_add_extra_chain_cert(ctx, cert);
 }
 
-static long SSL_CTX_auto_enable_ecdh_not_a_macro(SSL_CTX* ctx) {
-#if defined(SSL_CTX_set_ecdh_auto)
-        return SSL_CTX_set_ecdh_auto(ctx, 1);
-#else
-        EC_KEY *k = NULL;
-        k = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-        long result = SSL_CTX_set_tmp_ecdh(ctx, k);
-        EC_KEY_free(k);
-        return result;
-#endif
+static long SSL_CTX_set_tmp_ecdh_not_a_macro(SSL_CTX* ctx, EC_KEY *key) {
+    return SSL_CTX_set_tmp_ecdh(ctx, key);
 }
 
 #ifndef SSL_MODE_RELEASE_BUFFERS
@@ -210,14 +202,33 @@ func NewCtxFromFiles(cert_file string, key_file string) (*Ctx, error) {
 	return ctx, nil
 }
 
-// EnableECDH sets the elliptic curve on the context to enable an
-// ECDH cipher suite to be selected.
-func (c *Ctx) EnableECDH() error {
+// EllipticCurve repesents the ASN.1 OID of an elliptic curve.
+// see https://www.openssl.org/docs/apps/ecparam.html for a list of implemented curves.
+type EllipticCurve int
+
+const (
+	// P-256: X9.62/SECG curve over a 256 bit prime field
+	Prime256v1 EllipticCurve = C.NID_X9_62_prime256v1
+	// P-384: NIST/SECG curve over a 384 bit prime field
+	Secp384r1 EllipticCurve = C.NID_secp384r1
+)
+
+// SetEllipticCurve sets the elliptic curve used by the SSL context to
+// enable an ECDH cipher suite to be selected during the handshake.
+func (c *Ctx) SetEllipticCurve(curve EllipticCurve) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	if int(C.SSL_CTX_auto_enable_ecdh_not_a_macro(c.ctx)) != 1 {
+
+	k := C.EC_KEY_new_by_curve_name(C.int(curve))
+	if k == nil {
+		return errors.New("Unknown curve")
+	}
+	defer C.EC_KEY_free(k)
+
+	if int(C.SSL_CTX_set_tmp_ecdh_not_a_macro(c.ctx, k)) != 1 {
 		return errorFromErrorQueue()
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
To enable the use of ECDH, the SSL context has to have an ECDH key.

In openssl 1.0.2 (not yet released), `SSL_CTX_set_ecdh_auto` can be used. As a fallback, `SSL_CTX_set_tmp_ecdh` can be used with a named curve. 
