### PR TITLE
fix mingw-w64 url path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ### Using on Windows
-1. Install [mingw-w64](mingw-w64.sourceforge.net)
+1. Install [mingw-w64](http://mingw-w64.sourceforge.net/)
 2. Install [pkg-config-lite](http://sourceforge.net/projects/pkgconfiglite)
 3. Build (or install precompiled) openssl for mingw32-w64
 4. Set __PKG\_CONFIG\_PATH__ to the directory containing openssl.pc


### PR DESCRIPTION
Currently the mingw path is relative and points to a directory in the Github repo. Adding http prefix makes the URL absolute, which I believe it's supposed to be.
