### PR TITLE
OSX fixes

### DIFF
--- a/build.go
+++ b/build.go
@@ -18,4 +18,5 @@ package openssl
 
 // #cgo pkg-config: libssl
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
+// #cgo darwin CFLAGS: -Wno-deprecated-declarations
 import "C"

--- a/ctx.go
+++ b/ctx.go
@@ -63,7 +63,7 @@ static long SSL_CTX_set_tmp_ecdh_not_a_macro(SSL_CTX* ctx, EC_KEY *key) {
 #endif
 
 static const SSL_METHOD *OUR_TLSv1_1_method() {
-#ifdef TLS1_1_VERSION
+#if defined(TLS1_1_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
     return TLSv1_1_method();
 #else
     return NULL;
@@ -71,7 +71,7 @@ static const SSL_METHOD *OUR_TLSv1_1_method() {
 }
 
 static const SSL_METHOD *OUR_TLSv1_2_method() {
-#ifdef TLS1_2_VERSION
+#if defined(TLS1_2_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
     return TLSv1_2_method();
 #else
     return NULL;

--- a/key.go
+++ b/key.go
@@ -321,7 +321,7 @@ func GenerateRSAKey(bits int) (PrivateKey, error) {
 	if key == nil {
 		return nil, errors.New("failed to allocate EVP_PKEY")
 	}
-	if C.EVP_PKEY_assign(key, C.EVP_PKEY_RSA, unsafe.Pointer(rsa)) != 1 {
+	if C.EVP_PKEY_assign(key, C.EVP_PKEY_RSA, (*C.char)(unsafe.Pointer(rsa))) != 1 {
 		C.EVP_PKEY_free(key)
 		return nil, errors.New("failed to assign RSA key")
 	}


### PR DESCRIPTION
The OpenSSL version on OSX (at least on Mavericks) does not have the tls version method functions, so we need to detect OSX there. It doesn't look like there's a good way to put this into the compat file without adding yet another layer of indirection, so I put it directly in the ifdef.

The second commit is just to shut up the compiler. I already know Apple want me to use SecureTransport, I don't need it hiding any useful warnings or errors from my code.

The last one shouldn't be OSX-specific, but newer Go versions have gotten quite picky about C pointer types, so this makes them agree completely. I'm on 1.4 currently but I've seen similar issues on 1.3.