### PR TITLE
make CertificateInfo Serial type to *big.Int

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -27,6 +27,7 @@ import "C"
 import (
 	"errors"
 	"io/ioutil"
+	"math/big"
 	"runtime"
 	"time"
 	"unsafe"
@@ -57,7 +58,7 @@ type Certificate struct {
 }
 
 type CertificateInfo struct {
-	Serial       int
+	Serial       *big.Int
 	Issued       time.Duration
 	Expires      time.Duration
 	Country      string
@@ -193,8 +194,20 @@ func (c *Certificate) SetIssuerName(name *Name) error {
 }
 
 // SetSerial sets the serial of a certificate.
-func (c *Certificate) SetSerial(serial int) error {
-	if C.ASN1_INTEGER_set(C.X509_get_serialNumber(c.x), C.long(serial)) != 1 {
+func (c *Certificate) SetSerial(serial *big.Int) error {
+	sno := C.ASN1_INTEGER_new()
+	defer C.ASN1_INTEGER_free(sno)
+	bn := C.BN_new()
+	defer C.BN_free(bn)
+
+	serialBytes := serial.Bytes()
+	if bn = C.BN_bin2bn((*C.uchar)(unsafe.Pointer(&serialBytes[0])), C.int(len(serialBytes)), bn); bn == nil {
+		return errors.New("failed to set serial")
+	}
+	if sno = C.BN_to_ASN1_INTEGER(bn, sno); sno == nil {
+		return errors.New("failed to set serial")
+	}
+	if C.X509_set_serialNumber(c.x, sno) != 1 {
 		return errors.New("failed to set serial")
 	}
 	return nil

--- a/cert_test.go
+++ b/cert_test.go
@@ -15,6 +15,7 @@
 package openssl
 
 import (
+	"math/big"
 	"testing"
 	"time"
 )
@@ -25,7 +26,7 @@ func TestCertGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	info := &CertificateInfo{
-		Serial:       1,
+		Serial:       big.NewInt(int64(1)),
 		Issued:       0,
 		Expires:      24 * time.Hour,
 		Country:      "US",
@@ -47,7 +48,7 @@ func TestCAGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	info := &CertificateInfo{
-		Serial:       1,
+		Serial:       big.NewInt(int64(1)),
 		Issued:       0,
 		Expires:      24 * time.Hour,
 		Country:      "US",
@@ -74,7 +75,7 @@ func TestCAGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	info = &CertificateInfo{
-		Serial:       1,
+		Serial:       big.NewInt(int64(1)),
 		Issued:       0,
 		Expires:      24 * time.Hour,
 		Country:      "US",


### PR DESCRIPTION
Regarding to http://golang.org/pkg/crypto/x509/#Certificate , CertificateInfo Serial field type shoud be *big.Int