### PR TITLE
Session cache opts

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -42,6 +42,22 @@ static long SSL_CTX_set_session_cache_mode_not_a_macro(SSL_CTX* ctx, long modes)
    return SSL_CTX_set_session_cache_mode(ctx, modes);
 }
 
+static long SSL_CTX_sess_set_cache_size_not_a_macro(SSL_CTX* ctx, long t) {
+	return SSL_CTX_sess_set_cache_size(ctx, t);
+}
+
+static long SSL_CTX_sess_get_cache_size_not_a_macro(SSL_CTX* ctx) {
+	return SSL_CTX_sess_get_cache_size(ctx);
+}
+
+static long SSL_CTX_set_timeout_not_a_macro(SSL_CTX* ctx, long t) {
+   return SSL_CTX_set_timeout(ctx, t);
+}
+
+static long SSL_CTX_get_timeout_not_a_macro(SSL_CTX* ctx) {
+   return SSL_CTX_get_timeout(ctx);
+}
+
 static int CRYPTO_add_not_a_macro(int *pointer,int amount,int type) {
    return CRYPTO_add(pointer, amount, type);
 }
@@ -562,4 +578,28 @@ const (
 func (c *Ctx) SetSessionCacheMode(modes SessionCacheModes) SessionCacheModes {
 	return SessionCacheModes(
 		C.SSL_CTX_set_session_cache_mode_not_a_macro(c.ctx, C.long(modes)))
+}
+
+// Set session cache timeout in seconds. Returns previously set value.
+// See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+func (c *Ctx) SetTimeout(t int) int {
+	return int(C.SSL_CTX_set_timeout_not_a_macro(c.ctx, C.long(t)))
+}
+
+// Get session cache timeout in seconds.
+// See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+func (c *Ctx) GetTimeout() int {
+	return int(C.SSL_CTX_get_timeout_not_a_macro(c.ctx))
+}
+
+// Set session cache size. Returns previously set value.
+// https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
+func (c *Ctx) SessSetCacheSize(t int) int {
+	return int(C.SSL_CTX_sess_set_cache_size_not_a_macro(c.ctx, C.long(t)))
+}
+
+// Get session cache size.
+// https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
+func (c *Ctx) SessGetCacheSize() int {
+	return int(C.SSL_CTX_sess_get_cache_size_not_a_macro(c.ctx))
 }

--- a/ctx.go
+++ b/ctx.go
@@ -104,6 +104,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"time"
 	"unsafe"
 
 	"github.com/spacemonkeygo/spacelog"
@@ -580,16 +581,17 @@ func (c *Ctx) SetSessionCacheMode(modes SessionCacheModes) SessionCacheModes {
 		C.SSL_CTX_set_session_cache_mode_not_a_macro(c.ctx, C.long(modes)))
 }
 
-// Set session cache timeout in seconds. Returns previously set value.
+// Set session cache timeout. Returns previously set value.
 // See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
-func (c *Ctx) SetTimeout(t int) int {
-	return int(C.SSL_CTX_set_timeout_not_a_macro(c.ctx, C.long(t)))
+func (c *Ctx) SetTimeout(t time.Duration) time.Duration {
+	prev := C.SSL_CTX_set_timeout_not_a_macro(c.ctx, C.long(t/time.Second))
+	return time.Duration(prev) * time.Second
 }
 
-// Get session cache timeout in seconds.
+// Get session cache timeout.
 // See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
-func (c *Ctx) GetTimeout() int {
-	return int(C.SSL_CTX_get_timeout_not_a_macro(c.ctx))
+func (c *Ctx) GetTimeout() time.Duration {
+	return time.Duration(C.SSL_CTX_get_timeout_not_a_macro(c.ctx)) * time.Second
 }
 
 // Set session cache size. Returns previously set value.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -16,12 +16,13 @@ package openssl
 
 import (
 	"testing"
+	"time"
 )
 
 func TestCtxTimeoutOption(t *testing.T) {
 	ctx, _ := NewCtx()
 	oldTimeout1 := ctx.GetTimeout()
-	newTimeout1 := oldTimeout1 + 8362
+	newTimeout1 := oldTimeout1 + (time.Duration(99) * time.Second)
 	oldTimeout2 := ctx.SetTimeout(newTimeout1)
 	newTimeout2 := ctx.GetTimeout()
 	if oldTimeout1 != oldTimeout2 {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2014 Ryan Hileman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"testing"
+)
+
+func TestCtxTimeoutOption(t *testing.T) {
+	ctx, _ := NewCtx()
+	oldTimeout1 := ctx.GetTimeout()
+	newTimeout1 := oldTimeout1 + 8362
+	oldTimeout2 := ctx.SetTimeout(newTimeout1)
+	newTimeout2 := ctx.GetTimeout()
+	if oldTimeout1 != oldTimeout2 {
+		t.Error("SetTimeout() returns something undocumented")
+	}
+	if newTimeout1 != newTimeout2 {
+		t.Error("SetTimeout() does not save anything to ctx")
+	}
+}
+
+func TestCtxSessCacheSizeOption(t *testing.T) {
+	ctx, _ := NewCtx()
+	oldSize1 := ctx.SessGetCacheSize()
+	newSize1 := oldSize1 + 42
+	oldSize2 := ctx.SessSetCacheSize(newSize1)
+	newSize2 := ctx.SessGetCacheSize()
+	if oldSize1 != oldSize2 {
+		t.Error("SessSetCacheSize() returns something undocumented")
+	}
+	if newSize1 != newSize2 {
+		t.Error("SessSetCacheSize() does not save anything to ctx")
+	}
+}


### PR DESCRIPTION
It might be useful to get/set session cache timeout and session cache size. 
Openssl provides us with https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html and https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html to perform this.

This pull requests adds above methods to Ctx.