### PR TITLE
exposed TLS SNI extension

### DIFF
--- a/build.go
+++ b/build.go
@@ -16,7 +16,7 @@
 
 package openssl
 
-// #cgo pkg-config: libssl
+// #cgo pkg-config: libssl libcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 // #cgo darwin CFLAGS: -Wno-deprecated-declarations
 import "C"

--- a/conn.go
+++ b/conn.go
@@ -548,6 +548,11 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
 }
 
+func (c *Conn) SetCtx(ctx *Ctx) {
+	c.ctx = ctx
+	C.SSL_set_SSL_CTX(c.ssl, ctx.ctx)
+}
+
 func (c *Conn) UnderlyingConn() net.Conn {
 	return c.conn
 }

--- a/conn.go
+++ b/conn.go
@@ -566,3 +566,7 @@ func (c *Conn) SetTlsExtHostName(name string) error {
 func (c *Conn) VerifyResult() VerifyResult {
 	return VerifyResult(C.SSL_get_verify_result(c.ssl))
 }
+
+func (c *Conn) GetServerName() string {
+	return C.GoString(C.SSL_get_servername(c.ssl, C.TLSEXT_NAMETYPE_host_name))
+}

--- a/conn.go
+++ b/conn.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
 // +build cgo
 
 package openssl
@@ -30,6 +31,9 @@ package openssl
 // }
 // const char * SSL_get_cipher_name_not_a_macro(const SSL *ssl) {
 //    return SSL_get_cipher_name(ssl);
+// }
+// int SSL_version_not_a_macro(const SSL *ssl) {
+//    return SSL_version(ssl);
 // }
 import "C"
 
@@ -611,4 +615,8 @@ func (c *Conn) VerifyResult() VerifyResult {
 
 func (c *Conn) GetServerName() string {
 	return C.GoString(C.SSL_get_servername(c.ssl, C.TLSEXT_NAMETYPE_host_name))
+}
+
+func (c *Conn) Version() int {
+	return int(C.SSL_version_not_a_macro(c.ssl))
 }

--- a/ctx.go
+++ b/ctx.go
@@ -79,10 +79,10 @@ typedef struct CtxWrapper {
     SSL_CTX *ctx;
 } CtxWrapper;
 
-extern int call_servername_cb(SSL* ssl, int ad, void* arg);
+extern int callServerNameCb(SSL* ssl, int ad, void* arg);
 
 static int call_go_servername(SSL* ssl, int ad, void* arg) {
-    return call_servername_cb(ssl, ad, arg);
+    return callServerNameCb(ssl, ad, arg);
 }
 
 static int servername_gateway(CtxWrapper* cw) {
@@ -635,8 +635,8 @@ func (c *Ctx) SessGetCacheSize() int {
 // https://www.openssl.org/docs/manmaster/ssl/???
 //type ServerNameCallback func(ssl *C.SSL, ad C.int, arg unsafe.Pointer) int
 
-//export call_servername_cb
-func call_servername_cb(ssl *C.SSL, ad C.int, arg unsafe.Pointer) C.int {
+//export callServerNameCb
+func callServerNameCb(ssl *C.SSL, ad C.int, arg unsafe.Pointer) C.int {
 	var c *Ctx = (*Ctx)(arg)
 
 	//setup a dummy Conn so we can associate a SSL_CTX from user callback

--- a/ctx.go
+++ b/ctx.go
@@ -81,7 +81,7 @@ typedef struct TlsServernameData {
 } TlsServernameData;
 
 static TlsServernameData* new_TlsServernameData() {
-    return malloc(sizeof(TlsServernameData));
+    return calloc(1, sizeof(TlsServernameData));
 }
 
 //UNUSED: openssl doesn't have a way to unset SNI callback or arg. So we just leak whatever

--- a/ctx.go
+++ b/ctx.go
@@ -141,13 +141,12 @@ var (
 )
 
 type Ctx struct {
-	ctx       *C.SSL_CTX
-	cert      *Certificate
-	chain     []*Certificate
-	key       PrivateKey
-	verify_cb VerifyCallback
-	//servername_cb ServerNameCallback
-	servername_cb func(ssl Conn, ad int, arg unsafe.Pointer) int
+	ctx           *C.SSL_CTX
+	cert          *Certificate
+	chain         []*Certificate
+	key           PrivateKey
+	verify_cb     VerifyCallback
+	servername_cb ServerNameCallback
 	ted           C.TlsServernameData
 }
 
@@ -635,7 +634,7 @@ func (c *Ctx) SessGetCacheSize() int {
 
 // Set SSL_CTX_set_tlsext_servername_callback
 // https://www.openssl.org/docs/manmaster/ssl/???
-//type ServerNameCallback func(ssl *C.SSL, ad C.int, arg unsafe.Pointer) int
+type ServerNameCallback func(ssl Conn, ad int, arg unsafe.Pointer) int
 
 //export callServerNameCb
 func callServerNameCb(ssl *C.SSL, ad C.int, arg unsafe.Pointer) C.int {
@@ -651,8 +650,8 @@ func callServerNameCb(ssl *C.SSL, ad C.int, arg unsafe.Pointer) C.int {
 	return C.int(ret)
 }
 
-//func (c *Ctx) SetTlsExtServerNameCallback(cb ServerNameCallback) int {
-func (c *Ctx) SetTlsExtServerNameCallback(cb func(ssl Conn, ad int, arg unsafe.Pointer) int, arg unsafe.Pointer) int {
+func (c *Ctx) SetTlsExtServerNameCallback(cb func(ssl Conn, ad int, arg unsafe.Pointer) int,
+	arg unsafe.Pointer) int {
 	c.servername_cb = cb
 	c.ted = C.TlsServernameData{
 		go_ctx: unsafe.Pointer(c),

--- a/ctx.go
+++ b/ctx.go
@@ -664,6 +664,9 @@ func (c *Ctx) SetTlsExtServerNameCallback(cb func(ssl Conn, ad int, arg unsafe.P
 	arg unsafe.Pointer) int {
 	c.servername_cb = cb
 	ted := C.new_TlsServernameData()
+	if ted == nil {
+		return 1
+	}
 	ted.go_ctx = unsafe.Pointer(c)
 	ted.ctx = c.ctx
 	ted.arg = arg

--- a/tls_ext_test.go
+++ b/tls_ext_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+var gFoundServerName bool = false
+var gServerName string
+var gCallbackData string = "some callback data"
+
+func passThroughServername() func(ssl Conn, ad int, arg unsafe.Pointer) int {
+	x := func(ssl Conn, ad int, arg unsafe.Pointer) int {
+		cbData := (*string)(arg)
+		if *cbData != gCallbackData { //we should getthe callback data we set on the CTX
+			return 1
+		}
+		name := ssl.GetServerName()
+		if name == gServerName {
+			gFoundServerName = true
+			//here we'd normally do soemthing like get a CTX for the specific server name and
+			//set it on the conn.
+		} else {
+			gFoundServerName = false
+		}
+		return 0
+	}
+	return x
+}
+
+func TestTLSExtSNI(t *testing.T) {
+	//setup SNI On the CTX
+	server_conn, client_conn := NetPipe(t)
+	defer server_conn.Close()
+	defer client_conn.Close()
+
+	server, client := OpenSSLConstructor(t, server_conn, client_conn)
+	cconn := client.(*Conn)
+	sconn := server.(*Conn)
+	ctx := (*sconn).ctx
+	//setup SNI On the CTX
+	rc := ctx.SetTlsExtServerNameCallback(passThroughServername(), unsafe.Pointer(&gCallbackData))
+	if rc != 0 {
+		t.Fatal("Expected 0 from ctx.SetTlsExtServerNameCallback, but got %d", rc)
+	}
+	data := "first test string\n"
+	host := "test-host"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		gServerName = host
+		err := cconn.SetTlsExtHostName(host)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.Handshake()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = io.Copy(client, bytes.NewReader([]byte(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+
+		err := server.Handshake()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf := bytes.NewBuffer(make([]byte, 0, len(data)))
+		_, err = io.CopyN(buf, server, int64(len(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(buf.Bytes()) != data {
+			t.Fatal("mismatched data")
+		}
+
+		err = server.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	wg.Wait()
+	if gFoundServerName == false {
+		t.Fatal("Expected gFoundServerName to be set to true")
+	}
+	if gServerName != host {
+		t.Fatal("Expected gServerName to be '%s', but it was '%s'", host, gServerName)
+	}
+}


### PR DESCRIPTION
This change allows a server using spacemonkeygo/openssl to get the TLS extension server name in the standard openssl way (a hostname specified by clients).
