### PR TITLE
Fix build with openssl 1.0.2d

### DIFF
--- a/build.go
+++ b/build.go
@@ -16,7 +16,7 @@
 
 package openssl
 
-// #cgo pkg-config: libssl
+// #cgo pkg-config: libssl libcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 // #cgo darwin CFLAGS: -Wno-deprecated-declarations
 import "C"


### PR DESCRIPTION
On Fedora 23, the build fails like this:

	go build
	# github.com/spacemonkeygo/openssl
	/usr/bin/ld: $WORK/github.com/spacemonkeygo/openssl/_obj/cert.cgo2.o: undefined reference to symbol 'EVP_dss1@@libcrypto.so.10'
	/usr/lib64/libcrypto.so.10: error adding symbols: DSO missing from command line
	collect2: error: ld returned 1 exit status

Adding "libcrypto" to the linker flags fixes the issue.