### PR TITLE
fips.go

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -1,0 +1,21 @@
+// +build cgo
+
+package openssl
+
+/*
+#include <openssl/ssl.h>
+*/
+import "C"
+
+func FIPSModeSet(mode bool) error {
+	var r C.int
+	if mode {
+		r = C.FIPS_mode_set(1)
+	} else {
+		r = C.FIPS_mode_set(0)
+	}
+	if r != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}


### PR DESCRIPTION
This is close to the fips.go file that we use. The only difference is that we don't compile this on osx via a patch that looks like: 

```
diff --git a/fips.go b/fips.go
index df0a9c0..cc463f1 100644
--- a/fips.go
+++ b/fips.go
@@ -1,4 +1,5 @@
 // +build cgo
+// +build -darwin

 package openssl
```
