### PR TITLE
Avoid cgoPointerCheck in Write().

### DIFF
--- a/sha256.go
+++ b/sha256.go
@@ -21,6 +21,7 @@ package openssl
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include "openssl/evp.h"
 


### PR DESCRIPTION
In benchmarks `cgoPointerCheck` was taking about the same time as `cgocall EVP_DigestUpdate` and
making `SHA256Hash` run about 30% slower than the Go stdlib implementation of SHA256 in Go 1.6.  With this change it runs about 60% faster.
