### PR TITLE
expand the brew tag to support full feature set on OSX

### DIFF
--- a/build.go
+++ b/build.go
@@ -20,5 +20,5 @@ package openssl
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 // #cgo darwin CFLAGS: -Wno-deprecated-declarations
 // #cgo brew CFLAGS: -I/usr/local/opt/openssl/include/
-// #cgo brew LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a
+// #cgo brew LDFLAGS: -L/usr/local/opt/openssl/lib -lcrypto
 import "C"

--- a/build.go
+++ b/build.go
@@ -19,4 +19,6 @@ package openssl
 // #cgo pkg-config: libssl libcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 // #cgo darwin CFLAGS: -Wno-deprecated-declarations
+// #cgo brew CFLAGS: -I/usr/local/opt/openssl/include/
+// #cgo brew LDFLAGS: /usr/local/opt/openssl/lib/libcrypto.a
 import "C"

--- a/ciphers_gcm.go
+++ b/ciphers_gcm.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build cgo,!darwin,brew
+// +build cgo,!darwin cgo,brew
 
 package openssl
 

--- a/ciphers_gcm.go
+++ b/ciphers_gcm.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build cgo,!darwin
+// +build cgo,!darwin,brew
 
 package openssl
 

--- a/ciphers_test.go
+++ b/ciphers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !darwin
+// +build !darwin,brew
 
 package openssl
 

--- a/ciphers_test.go
+++ b/ciphers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !darwin,brew
+// +build !darwin brew
 
 package openssl
 

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -191,6 +191,8 @@ func ClosingTest(t testing.TB, constructor func(
 
 	run_test := func(close_tcp bool, server_writes bool) {
 		server_conn, client_conn := NetPipe(t)
+		server_conn.SetDeadline(time.Now().Add(2 * time.Second))
+		client_conn.SetDeadline(time.Now().Add(2 * time.Second))
 		defer server_conn.Close()
 		defer client_conn.Close()
 		server, client := constructor(t, server_conn, client_conn)


### PR DESCRIPTION
There was a brew tag used in a few places which would re-enable building some features on OSX.  I expanded the use of it so that it enables building all of the features and tests, including AES-GCM.  Also sets some build flags to ensure the brew'ed version of openssl is found.

This also fixes building on el capitan.  Prior to this pull request, the build would fail entirely because the openssl headers are no longer distributed with osx.

Also fixed a test to ensure if fails instead of hanging.
