### PR TITLE
Get and Set the x509 version

### DIFF
--- a/cert_test.go
+++ b/cert_test.go
@@ -37,6 +37,21 @@ func TestCertGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	v := cert.GetVersion()
+	if v != X509_V1 {
+		t.Fatal("Version should be X509_V1.")
+	}
+
+	if err := cert.SetVersion(X509_V3); err != nil {
+		t.Fatal(err)
+	}
+
+	v = cert.GetVersion()
+	if v != X509_V3 {
+		t.Fatal("Version should be X509_V3.")
+	}
+
 	if err := cert.Sign(key, EVP_SHA256); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Many x509 extensions require that the certificate is x509v3, however
openssl creates x509v1 certificates by default. This patch adds
support for setting the certificate version to x509v3

https://github.com/spacemonkeygo/openssl/issues/60

Signed-off-by: Stephen Gallagher sgallagh@redhat.com
