### PR TITLE
Make test confom to new requirement enforced in go 1.10

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -77,7 +77,7 @@ func TestMarshal(t *testing.T) {
 	}
 	tls_der := x509.MarshalPKCS1PrivateKey(tls_key)
 	if !bytes.Equal(der, tls_der) {
-		t.Fatal("invalid private key der bytes: %s\n v.s. %s\n",
+		t.Fatalf("invalid private key der bytes: %s\n v.s. %s\n",
 			hex.Dump(der), hex.Dump(tls_der))
 	}
 
@@ -291,7 +291,7 @@ func TestMarshalEC(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(der, tls_der) {
-		t.Fatal("invalid private key der bytes: %s\n v.s. %s\n",
+		t.Fatalf("invalid private key der bytes: %s\n v.s. %s\n",
 			hex.Dump(der), hex.Dump(tls_der))
 	}
 

--- a/sha1_test.go
+++ b/sha1_test.go
@@ -35,7 +35,7 @@ func TestSHA1(t *testing.T) {
 		}
 
 		if expected != got {
-			t.Fatal("exp:%x got:%x", expected, got)
+			t.Fatalf("exp:%x got:%x", expected, got)
 		}
 	}
 }
@@ -73,7 +73,7 @@ func TestSHA1Writer(t *testing.T) {
 		}
 
 		if got != exp {
-			t.Fatal("exp:%x got:%x", exp, got)
+			t.Fatalf("exp:%x got:%x", exp, got)
 		}
 	}
 }

--- a/sha256_test.go
+++ b/sha256_test.go
@@ -35,7 +35,7 @@ func TestSHA256(t *testing.T) {
 		}
 
 		if expected != got {
-			t.Fatal("exp:%x got:%x", expected, got)
+			t.Fatalf("exp:%x got:%x", expected, got)
 		}
 	}
 }
@@ -73,7 +73,7 @@ func TestSHA256Writer(t *testing.T) {
 		}
 
 		if got != exp {
-			t.Fatal("exp:%x got:%x", exp, got)
+			t.Fatalf("exp:%x got:%x", exp, got)
 		}
 	}
 }


### PR DESCRIPTION
https://tip.golang.org/doc/go1.10#test. With out this change tests will always fails with go 1.10+.
```
# github.com/spacemonkeygo/openssl
go/src/github.com/spacemonkeygo/openssl/key_test.go:80: Fatal call has possible formatting directive %s
go/src/github.com/spacemonkeygo/openssl/key_test.go:294: Fatal call has possible formatting directive %s
go/src/github.com/spacemonkeygo/openssl/sha1_test.go:38: Fatal call has possible formatting directive %x
go/src/github.com/spacemonkeygo/openssl/sha1_test.go:76: Fatal call has possible formatting directive %x
go/src/github.com/spacemonkeygo/openssl/sha256_test.go:38: Fatal call has possible formatting directive %x
go/src/github.com/spacemonkeygo/openssl/sha256_test.go:76: Fatal call has possible formatting directive %x
FAIL	github.com/spacemonkeygo/openssl [build failed]
```
