### PR TITLE
Set thread id callback as required by openssl.

### DIFF
--- a/init_posix.go
+++ b/init_posix.go
@@ -60,5 +60,13 @@ void go_thread_locking_callback(int mode, int n, const char *file,
 		pthread_mutex_unlock(&goopenssl_locks[n]);
 	}
 }
+
+unsigned long go_thread_id_callback(void)
+{
+    unsigned long ret;
+
+    ret = (unsigned long)pthread_self();
+    return (ret);
+}
 */
 import "C"

--- a/shim.c
+++ b/shim.c
@@ -33,6 +33,7 @@
  */
 extern int go_init_locks();
 extern void go_thread_locking_callback(int, int, const char*, int);
+extern unsigned long go_thread_id_callback();
 static int go_write_bio_puts(BIO *b, const char *str) {
 	return go_write_bio_write(b, (char*)str, (int)strlen(str));
 }
@@ -325,14 +326,13 @@ int X_shim_init() {
 	SSL_library_init();
 	OpenSSL_add_all_algorithms();
 	//
-	// Set up OPENSSL thread safety callbacks.  We only set the locking
-	// callback because the default id callback implementation is good
-	// enough for us.
+	// Set up OPENSSL thread safety callbacks.  
 	rc = go_init_locks();
 	if (rc != 0) {
 		return rc;
 	}
 	CRYPTO_set_locking_callback(go_thread_locking_callback);
+	CRYPTO_set_id_callback(go_thread_id_callback)
 
 	rc = x_bio_init_methods();
 	if (rc != 0) {


### PR DESCRIPTION
For openssl to work in multi threaded environment, 2 callbacks needs to be set as per following blog.
https://www.openssl.org/blog/blog/2017/02/21/threads/

Spacemonkeygo openssl binding is setting CRYPTO_set_locking_callback but not setting CRYPTO_set_id_callback. I have added required changes for setting CRYPTO_set_id_callback for non windows environment.
