### PR TITLE
add wrappers to enable/disable Padding for encryption contexts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Space Monkey, Inc <hello@spacemonkey.com>
 Stephen Gallagher <sgallagh@redhat.com>
 Viacheslav Biriukov <v.v.biriukov@gmail.com>
 Zack Owens <zowens2009@gmail.com>
+Ramesh Rayaprolu <rarayapr@cisco.com>

--- a/ciphers.go
+++ b/ciphers.go
@@ -148,6 +148,13 @@ func (ctx *cipherCtx) IVSize() int {
 	return int(C.X_EVP_CIPHER_CTX_iv_length(ctx.ctx))
 }
 
+func (ctx *cipherCtx) SetPadding(pad bool) {
+	if pad {
+		C.X_EVP_CIPHER_CTX_set_padding(ctx.ctx, 1)
+	}
+	C.X_EVP_CIPHER_CTX_set_padding(ctx.ctx, 0)
+}
+
 func (ctx *cipherCtx) setCtrl(code, arg int) error {
 	res := C.EVP_CIPHER_CTX_ctrl(ctx.ctx, C.int(code), C.int(arg), nil)
 	if res != 1 {

--- a/shim.c
+++ b/shim.c
@@ -664,6 +664,12 @@ int X_EVP_CIPHER_CTX_iv_length(EVP_CIPHER_CTX *ctx) {
     return EVP_CIPHER_CTX_iv_length(ctx);
 }
 
+void X_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding) {
+    //openssl always returns 1 for set_padding
+    //hence return value is not checked 
+    EVP_CIPHER_CTX_set_padding(ctx, padding);
+}
+
 const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx) {
     return EVP_CIPHER_CTX_cipher(ctx);
 }

--- a/shim.h
+++ b/shim.h
@@ -139,6 +139,7 @@ extern int X_EVP_CIPHER_nid(EVP_CIPHER *c);
 extern int X_EVP_CIPHER_CTX_block_size(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_key_length(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_iv_length(EVP_CIPHER_CTX *ctx);
+extern void X_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
 extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
 extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);


### PR DESCRIPTION
We needed to disable and use customized padding in our product. This code change enables us (and others who need it) to have custom padding.