### PR TITLE
Add SetSupportedEllipticCurves function

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -201,6 +201,22 @@ func (c *Ctx) SetEllipticCurve(curve EllipticCurve) error {
 	return nil
 }
 
+// SetSupportedEllipticCurves sets the supported elliptic curves used by the SSL context.
+func (c *Ctx) SetSupportedEllipticCurves(curves []EllipticCurve) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	clist := make([]C.int, len(curves))
+	for i, curve := range curves {
+		clist[i] = C.int(curve)
+	}
+	if int(C.X_SSL_CTX_set1_curves(c.ctx, &clist[0], C.int(len(curves)))) != 1 {
+		return errorFromErrorQueue()
+	}
+
+	return nil
+}
+
 // UseCertificate configures the context to present the given certificate to
 // peers.
 func (c *Ctx) UseCertificate(cert *Certificate) error {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/spacemonkeygo/openssl
+module github.com/exosite/openssl
 
 require github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572

--- a/shim.c
+++ b/shim.c
@@ -562,6 +562,10 @@ int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
 	return go_ticket_key_cb_thunk(p, s, key_name, iv, cctx, hctx, enc);
 }
 
+int X_SSL_CTX_set1_curves(SSL_CTX* ctx, int *clist, int clistlen) {
+    return SSL_CTX_set1_curves(ctx, clist, clistlen);
+}
+
 int X_BIO_get_flags(BIO *b) {
 	return BIO_get_flags(b);
 }

--- a/shim.h
+++ b/shim.h
@@ -89,6 +89,7 @@ extern int X_SSL_CTX_set_tlsext_ticket_key_cb(SSL_CTX *sslctx,
 extern int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
         unsigned char iv[EVP_MAX_IV_LENGTH],
         EVP_CIPHER_CTX *cctx, HMAC_CTX *hctx, int enc);
+extern int X_SSL_CTX_set1_curves(SSL_CTX *ctx, int *clist, int clistlen);
 
 /* BIO methods */
 extern int X_BIO_get_flags(BIO *b);


### PR DESCRIPTION
The `SetEllipticCurve` function didn't change supported groups list in request. So I add `SetSupportedEllipticCurves` function to set supported groups list properly.

Because the curve functions were first added to OpenSSL 1.0.2 (see https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set1_groups.html), maybe this function should support the old versions?
