### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -311,7 +311,7 @@ func getDigestFunction(digest EVP_MD) (md *C.EVP_MD) {
 	return md
 }
 
-// Add an extension to a certificate.
+// AddExtension adds an extension to a certificate.
 // Extension constants are NID_* as found in openssl.
 func (c *Certificate) AddExtension(nid NID, value string) error {
 	issuer := c

--- a/ctx.go
+++ b/ctx.go
@@ -549,7 +549,7 @@ func (c *Ctx) SetTimeout(t time.Duration) time.Duration {
 	return time.Duration(prev) * time.Second
 }
 
-// Get session cache timeout.
+// GetTimeout gets session cache timeout.
 // See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
 func (c *Ctx) GetTimeout() time.Duration {
 	return time.Duration(C.X_SSL_CTX_get_timeout(c.ctx)) * time.Second
@@ -561,7 +561,7 @@ func (c *Ctx) SessSetCacheSize(t int) int {
 	return int(C.X_SSL_CTX_sess_set_cache_size(c.ctx, C.long(t)))
 }
 
-// Get session cache size.
+// SessGetCacheSize gets session cache size.
 // https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
 func (c *Ctx) SessGetCacheSize() int {
 	return int(C.X_SSL_CTX_sess_get_cache_size(c.ctx))

--- a/digest.go
+++ b/digest.go
@@ -40,7 +40,7 @@ func GetDigestByName(name string) (*Digest, error) {
 	return &Digest{ptr: p}, nil
 }
 
-// GetDigestByName returns the Digest with the NID or nil and an error if the
+// GetDigestByNid returns the Digest with the NID or nil and an error if the
 // digest was not found.
 func GetDigestByNid(nid NID) (*Digest, error) {
 	sn, err := Nid2ShortName(nid)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?