### PR TITLE
Add signer method for pre-hashed data to allow tls/crypto to use openssl engines

### DIFF
--- a/key.go
+++ b/key.go
@@ -345,19 +345,22 @@ func LoadPrivateKeyFromPEM(pem_block []byte) (PrivateKey, error) {
 }
 
 // LoadPrivateKeyFromPEMForEngine loads the PEM formatted data that will be sent to the OpenSSL Engine
-func LoadPrivateKeyFromPEMForEngine(engine *Engine, pemFile string) (PrivateKey, error) {
+func LoadPrivateKeyFromPEMForEngine(engine *Engine, id string) (PrivateKey, error) {
 
-        if len(pemFile) == 0 {
-                return nil, errors.New("LoadPrivateKeyFromPEMForEngine: PEM file name not supplied")
+	// id is a reference for the openssl engine to use in whatever it needs to to find the private key.
+	// For example, for a TPM engine, this could be the full path and name of the file that holds PEM data that the
+	// TPM library can use to reference the private key in the TPM
+        if len(id) == 0 {
+                return nil, errors.New("LoadPrivateKeyFromPEMForEngine: Private Key ID not supplied")
         }
 
         var key *C.EVP_PKEY
 
-        fname := C.CString(pemFile)
-        defer C.free(unsafe.Pointer(fname))
+        pkid := C.CString(id)
+        defer C.free(unsafe.Pointer(pkid))
 
         // The PEM file will bw loaded by the engine library
-        key = C.X_ENGINE_load_private_key(engine.e, fname, nil, nil)
+        key = C.X_ENGINE_load_private_key(engine.e, pkid, nil, nil)
 
         p := &pKey{key: key}
         runtime.SetFinalizer(p, func(p *pKey) {

--- a/shim.c
+++ b/shim.c
@@ -768,3 +768,8 @@ long X_X509_get_version(const X509 *x) {
 int X_X509_set_version(X509 *x, long version) {
 	return X509_set_version(x, version);
 }
+
+int X_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) {
+    return EVP_PKEY_CTX_set_signature_md(ctx, md);
+}
+

--- a/shim.c
+++ b/shim.c
@@ -773,3 +773,7 @@ int X_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) {
     return EVP_PKEY_CTX_set_signature_md(ctx, md);
 }
 
+EVP_PKEY *X_ENGINE_load_private_key(ENGINE *e, const char *key_id, UI_METHOD *ui_method, void *callback_data) {
+    return ENGINE_load_private_key(e, key_id, ui_method, callback_data);
+}
+

--- a/shim.h
+++ b/shim.h
@@ -150,6 +150,7 @@ extern void X_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
 extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
 extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+extern int X_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
 /* HMAC methods */
 extern size_t X_HMAC_size(const HMAC_CTX *e);

--- a/shim.h
+++ b/shim.h
@@ -151,6 +151,7 @@ extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
 extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
 extern int X_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+extern EVP_PKEY *X_ENGINE_load_private_key(ENGINE *e, const char *key_id, UI_METHOD *ui_method, void *callback_data);
 
 /* HMAC methods */
 extern size_t X_HMAC_size(const HMAC_CTX *e);


### PR DESCRIPTION
I have added a new method cal;led SignPKCS1v15Hash which allows the tls/crypto Signer method to use an openssl engine to sign data. A TPM (Trusted Platform Module) can then be used with Go code, using the library from here

https://git.kernel.org/pub/scm/linux/kernel/git/jejb/openssl_tpm2_engine.git


There is also a function LoadPrivateKeyFromPEMForEngine which loads the engine with the reference to the private key.

