### PR TITLE
Update fips.go for OpenSSL 3.x compatability

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -21,16 +21,16 @@ import "C"
 import "runtime"
 
 // FIPSModeSet enables a FIPS 140-2 validated mode of operation.
-// https://wiki.openssl.org/index.php/FIPS_mode_set()
+//  https://www.openssl.org/docs/man3.0/man3/EVP_default_properties_is_fips_enabled.html
 func FIPSModeSet(mode bool) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	var r C.int
 	if mode {
-		r = C.FIPS_mode_set(1)
+		r = C.EVP_default_properties_enable_fips(nil, 1)
 	} else {
-		r = C.FIPS_mode_set(0)
+		r = C.EVP_default_properties_enable_fips(nil, 0)
 	}
 	if r != 1 {
 		return errorFromErrorQueue()


### PR DESCRIPTION
openssl 1.X api FIPS_mode_set() was deprecated and replaced with EVP_default_properties_enable_fips()

modify fips.go so it can link with libcrypto in the presence of a build with openssl 3.x