### PR TITLE
Add compatibility for OpenSSL 3.x.x in fips.go

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -15,22 +15,23 @@
 package openssl
 
 /*
-#include <openssl/ssl.h>
+#include <shim.h>
 */
 import "C"
 import "runtime"
 
 // FIPSModeSet enables a FIPS 140-2 validated mode of operation.
-// https://wiki.openssl.org/index.php/FIPS_mode_set()
+// OpenSSL 3.0.0 and greater - https://www.openssl.org/docs/man3.0/man3/EVP_default_properties_is_fips_enabled.html,
+// lower than 3.0.0 - https://wiki.openssl.org/index.php/FIPS_mode_set()
 func FIPSModeSet(mode bool) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	var r C.int
 	if mode {
-		r = C.FIPS_mode_set(1)
+		r = C.X_EVP_default_properties_enable_fips(nil, 1)
 	} else {
-		r = C.FIPS_mode_set(0)
+		r = C.X_EVP_default_properties_enable_fips(nil, 0)
 	}
 	if r != 1 {
 		return errorFromErrorQueue()

--- a/shim.c
+++ b/shim.c
@@ -779,8 +779,6 @@ int X_X509_set_version(X509 *x, long version) {
     return EVP_default_properties_enable_fips(libctx, enable);
   }
 #else
-  typedef void OSSL_LIB_CTX;
-
   int X_EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable) {
     return FIPS_mode_set(enable);
   }

--- a/shim.c
+++ b/shim.c
@@ -768,3 +768,20 @@ long X_X509_get_version(const X509 *x) {
 int X_X509_set_version(X509 *x, long version) {
 	return X509_set_version(x, version);
 }
+
+/*
+ ************************************************
+ * v3.0.0 and later implementation
+ ************************************************
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
+  int X_EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable) {
+    return EVP_default_properties_enable_fips(libctx, enable);
+  }
+#else
+  typedef void OSSL_LIB_CTX;
+
+  int X_EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable) {
+    return FIPS_mode_set(enable);
+  }
+#endif

--- a/shim.h
+++ b/shim.h
@@ -150,6 +150,15 @@ extern void X_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
 extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
 extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+
+/*
+ ************************************************
+ * v0.x.x and v1.x.x type compatibility
+ ************************************************
+ */
+#if OPENSSL_VERSION_NUMBER < 0x3000000fL
+  typedef void OSSL_LIB_CTX;
+#endif
 extern int X_EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
 
 /* HMAC methods */

--- a/shim.h
+++ b/shim.h
@@ -150,6 +150,7 @@ extern void X_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int padding);
 extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
 extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
 extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+extern int X_EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
 
 /* HMAC methods */
 extern size_t X_HMAC_size(const HMAC_CTX *e);


### PR DESCRIPTION
Added conditional defining of FIPS method for compatibility between 1.x and 3.x versions of OpenSSL.